### PR TITLE
Popups & Dialogs

### DIFF
--- a/winui-drover-island/winui-drover-island/DialogsAndPopupsDemo.cpp
+++ b/winui-drover-island/winui-drover-island/DialogsAndPopupsDemo.cpp
@@ -126,6 +126,12 @@ DialogsAndPopupsDemo::DialogsAndPopupsDemo() {
 
 	mDialog.CloseButtonText(L"Close");
 	mDialog.Content(winrt::box_value(L"Dialog Content"));
+
+	/* 
+		Setting the MaxWidth to some small value makes the dialog not appear
+		at center.
+	*/
+	mDialog.MaxWidth(500);
 }
 
 DialogsAndPopupsDemo::~DialogsAndPopupsDemo() {

--- a/winui-drover-island/winui-drover-island/DialogsAndPopupsDemo.cpp
+++ b/winui-drover-island/winui-drover-island/DialogsAndPopupsDemo.cpp
@@ -1,0 +1,143 @@
+/*
+ *  Copyright 2020 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+#include "pch.h"
+#include "DialogsAndPopupsDemo.h"
+
+#include <cstdint>
+
+namespace Xaml = ::winrt::Microsoft::UI::Xaml;
+using ::winrt::Microsoft::UI::Colors;
+
+namespace {
+
+constexpr double kPhi = 1.618033988749895;
+constexpr double kSpacing = 20.0;
+
+void closeEverything(
+		Xaml::Controls::UIElementCollection& children,
+		Xaml::Controls::ContentDialog& dialog,
+		Xaml::Controls::Primitives::Popup& popup,
+		Xaml::Controls::LayoutPanel& mErrorPanel) {
+	dialog.Hide();
+
+	uint32_t index;
+	if (children.IndexOf(popup, index)) {
+		popup.IsOpen(false);
+		children.RemoveAt(index);
+	}
+	
+	mErrorPanel.Visibility(Xaml::Visibility::Collapsed);
+}
+}
+
+namespace winui_drover_island {
+
+template <typename Fn>
+void DialogsAndPopupsDemo::tryFn(Fn&& fn) {
+	try {
+		closeEverything(mRoot.Children(), mDialog, mPopup, mErrorPanel);
+		fn();
+	}
+	catch (const winrt::hresult_error& error) {
+		mErrorText.Text(error.message());
+		mErrorPanel.Visibility(Xaml::Visibility::Visible);
+	}
+}
+
+DialogsAndPopupsDemo::DialogsAndPopupsDemo() {
+	mRoot.BorderBrush(Xaml::Media::SolidColorBrush(Colors::Silver()));
+	mRoot.BorderThickness(Xaml::Thickness{1, 1, 1, 1});
+	mRoot.Orientation(Xaml::Controls::Orientation::Vertical);
+	mRoot.Padding(Xaml::Thickness{kSpacing, kSpacing, kSpacing, 0});
+	mRoot.Spacing(kSpacing);
+	mRoot.HorizontalAlignment(Xaml::HorizontalAlignment::Stretch);
+	mRoot.VerticalAlignment(Xaml::VerticalAlignment::Top);
+	auto children = mRoot.Children();
+
+	Xaml::Controls::Button dialogButton;
+	dialogButton.Content(winrt::box_value(L"Show Dialog"));
+	dialogButton.HorizontalAlignment(Xaml::HorizontalAlignment::Center);
+	mRevokeDialogButton = 
+		dialogButton.Click(
+			winrt::auto_revoke,
+			[this](auto&&, auto&&) { 
+				tryFn([this] { 
+					/*
+						dialog throws if the line below is not uncommented.
+					*/
+					//mDialog.XamlRoot(mRoot.XamlRoot()); // uncomment to make it show
+					mDialog.ShowAsync();
+				}); 
+			});
+	children.Append(std::move(dialogButton));
+
+	Xaml::Controls::Button popupButton;
+	popupButton.Content(winrt::box_value(L"Show Popup"));
+	popupButton.HorizontalAlignment(Xaml::HorizontalAlignment::Center);
+	mRevokePopupButton = 
+		popupButton.Click(
+			winrt::auto_revoke, 
+			[this](auto&&, auto&&) {
+				tryFn([this] {
+					mRoot.Children().Append(mPopup);
+					mPopup.IsOpen(true);
+				});
+			});
+	children.Append(std::move(popupButton));
+
+	static const auto errorBrush = [] {
+		Xaml::Media::SolidColorBrush brush(Colors::Red());
+		brush.Opacity(0.5);
+		return brush;
+	}();
+	mErrorPanel.Background(errorBrush);
+	mErrorPanel.Margin(Xaml::Thickness{0, 0, 0, kSpacing});
+	mErrorPanel.Padding(Xaml::Thickness{kSpacing, kSpacing, kSpacing, kSpacing});
+	mErrorPanel.Visibility(Xaml::Visibility::Collapsed);
+	mErrorPanel.Children().Append(mErrorText);
+	children.Append(mErrorPanel);
+
+	Xaml::Controls::StackPanel popup;
+	popup.BorderThickness(Xaml::Thickness{1, 1, 1, 1});
+	popup.BorderBrush(Xaml::Media::SolidColorBrush(Colors::LightSeaGreen()));
+	popup.Background(Xaml::Media::SolidColorBrush(Colors::Aquamarine()));
+	popup.HorizontalAlignment(Xaml::HorizontalAlignment::Center);
+	popup.Padding(Xaml::Thickness{kSpacing, kSpacing, kSpacing, kSpacing});
+	
+	Xaml::Controls::TextBlock popupText;
+	popupText.Foreground(Xaml::Media::SolidColorBrush(Colors::Black()));
+	popupText.Text(L"Popup Content");
+	popup.Children().Append(std::move(popupText));
+
+	mPopup.Child(std::move(popup));
+	mPopup.IsLightDismissEnabled(true);
+	mPopup.LightDismissOverlayMode(Xaml::Controls::LightDismissOverlayMode::On);
+
+	mDialog.CloseButtonText(L"Close");
+	mDialog.Content(winrt::box_value(L"Dialog Content"));
+}
+
+DialogsAndPopupsDemo::~DialogsAndPopupsDemo() {
+	/* 
+		Crash in 
+		            ContentDialog::DetachEventHandlersForOpenDialog()
+		called from ContentDialog::~ContentDialog()
+	*/
+}
+
+Xaml::UIElement DialogsAndPopupsDemo::content() const {
+	return mRoot;
+}
+
+}

--- a/winui-drover-island/winui-drover-island/DialogsAndPopupsDemo.h
+++ b/winui-drover-island/winui-drover-island/DialogsAndPopupsDemo.h
@@ -14,30 +14,26 @@
 #pragma once
 
 #include <winrt/Microsoft.UI.Xaml.h>
-#include <winrt/winui_drover_island.h>
-
-#include "DroverIslandDemo.h"
-#include "DialogsAndPopupsDemo.h"
 
 namespace winui_drover_island {
 
-class WinUIWindow
-{
+class DialogsAndPopupsDemo {
+	using Click_revoker = winrt::Microsoft::UI::Xaml::Controls::Button::Click_revoker;
+
+	Click_revoker mRevokeDialogButton;
+	Click_revoker mRevokePopupButton;
+	winrt::Microsoft::UI::Xaml::Controls::ContentDialog mDialog;
+	winrt::Microsoft::UI::Xaml::Controls::Primitives::Popup mPopup;
+	winrt::Microsoft::UI::Xaml::Controls::LayoutPanel mErrorPanel;
+	winrt::Microsoft::UI::Xaml::Controls::TextBlock mErrorText;
+	winrt::Microsoft::UI::Xaml::Controls::StackPanel mRoot;
+
+	template <typename Fn>
+	void tryFn(Fn&&);
 public:
-	WinUIWindow();
-
-	void create();
-	void addContent();
-	void show();
-
-	const winrt::Microsoft::UI::Xaml::Window& window() const {
-		return mWindow;
-	};
-
-private:
-	winrt::Microsoft::UI::Xaml::Window mWindow{ nullptr };
-	DroverIslandDemo mDroverIslandDemo;
-	DialogsAndPopupsDemo mDialogsAndPopupsDemo;
+	DialogsAndPopupsDemo();
+	~DialogsAndPopupsDemo();
+	winrt::Microsoft::UI::Xaml::UIElement content() const;
 };
 
-}  // namespace winui_drover_island
+}

--- a/winui-drover-island/winui-drover-island/DroverIslandDemo.cpp
+++ b/winui-drover-island/winui-drover-island/DroverIslandDemo.cpp
@@ -1,0 +1,149 @@
+/*
+ *  Copyright 2020 Adobe Systems Incorporated. All rights reserved.
+ *  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License. You may obtain a copy
+ *  of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under
+ *  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ *  OF ANY KIND, either express or implied. See the License for the specific language
+ *  governing permissions and limitations under the License.
+ *
+ */
+
+#include "pch.h"
+#include "DroverIslandDemo.h"
+
+#include <winrt/Windows.UI.h>
+#include "DroverIsland.h"
+#include "EllipseShape.h"
+
+using namespace winrt::Microsoft::UI::Xaml::Controls;
+using namespace winrt::Microsoft::UI::Xaml;
+using namespace winrt::Windows::Foundation;
+
+namespace {
+Grid createGrid() {
+	// Setup the grid.
+	auto column1 = ColumnDefinition{};
+	column1.Width(GridLength{ 1, GridUnitType::Star });
+	auto column2 = ColumnDefinition{};
+	column2.Width(GridLength{ 2, GridUnitType::Star });
+	auto column3 = ColumnDefinition{};
+	column3.Width(GridLength{ 1, GridUnitType::Star });
+	auto row1 = RowDefinition{};
+	row1.Height(GridLength{ 0, GridUnitType::Auto });
+	auto row2 = RowDefinition{};
+	row2.Height(GridLength{ 0, GridUnitType::Auto });
+	auto row3 = RowDefinition{};
+	row3.Height(GridLength{ 0, GridUnitType::Auto });
+	auto row4 = RowDefinition{};
+	row4.Height(GridLength{ 1, GridUnitType::Star });
+
+	Grid grid;
+	grid.ColumnDefinitions().Append(column1);
+	grid.ColumnDefinitions().Append(column2);
+	grid.ColumnDefinitions().Append(column3);
+	grid.RowDefinitions().Append(row1);
+	grid.RowDefinitions().Append(row2);
+	grid.RowDefinitions().Append(row3);
+	grid.RowDefinitions().Append(row4);
+	return grid;
+}
+}
+
+namespace winui_drover_island {
+
+DroverIslandDemo::DroverIslandDemo() = default;
+
+UIElement DroverIslandDemo::createContent() {
+	mGrid = createGrid();
+
+	auto checkbox = CheckBox{};
+	checkbox.Margin({ 20, 0, 0, 0 });
+	checkbox.Content(winrt::box_value(L"Enable Virtual Surface"));
+	mCheckedRevoker = checkbox.Checked(winrt::auto_revoke, [this](const IInspectable&, const RoutedEventArgs&) { mUseVSIS = true; });
+	mUncheckedRevoker = checkbox.Unchecked(winrt::auto_revoke, [this](const IInspectable&, const RoutedEventArgs&) { mUseVSIS = false; });
+	mGrid.Children().Append(checkbox);
+
+	auto title = TextBlock{};
+	title.Text(L"Playground for supporting Drover Islands in WinUI");
+	mGrid.Children().Append(title);
+	Grid::SetColumn(title, 1);
+	Grid::SetRow(title, 0);
+	title.HorizontalAlignment(HorizontalAlignment::Center);
+	title.Margin({ 0, 20, 0, 20 });
+	title.FontSize(32);
+	title.TextWrapping(TextWrapping::Wrap);
+
+	auto button = Button{};
+	button.Content(winrt::box_value(L"Click me to render the next control!"));
+	mGrid.Children().Append(button);
+	Grid::SetColumn(button, 1);
+	Grid::SetRow(button, 1);
+	button.HorizontalAlignment(HorizontalAlignment::Center);
+	mClickRevoker = button.Click(winrt::auto_revoke, [this](const IInspectable&, const RoutedEventArgs&) {
+		renderCanvasControl(pickNextControl());
+		});
+
+	auto description = TextBlock{};
+	mGrid.Children().Append(description);
+	Grid::SetColumn(description, 1);
+	Grid::SetRow(description, 2);
+	description.HorizontalAlignment(HorizontalAlignment::Center);
+	description.Margin({ 0, 20, 0, 20 });
+	description.TextWrapping(TextWrapping::Wrap);
+	mDescription = description;
+
+	mCanvasContainer = Border{};
+	mGrid.Children().Append(mCanvasContainer);
+	Grid::SetColumn(mCanvasContainer, 1);
+	Grid::SetRow(mCanvasContainer, 3);
+	Media::SolidColorBrush brush;
+	brush.Color(winrt::Windows::UI::Colors::Gray());
+	mCanvasContainer.Margin({ 0, 0, 0, 20 });
+	mCanvasContainer.BorderBrush(brush);
+	mCanvasContainer.BorderThickness(Thickness{ 2, 2, 2, 2 });
+
+	renderCanvasControl(mControlType);
+	return mGrid;
+}
+
+DroverIslandDemo::Type DroverIslandDemo::pickNextControl() {
+	switch (mControlType) {
+	case Type::Ellipse: return Type::DroverSample;
+	case Type::DroverSample: return Type::None;
+	default: return Type::Ellipse;
+	}
+}
+
+void DroverIslandDemo::renderCanvasControl(Type type) {
+	switch (type) {
+	case Type::None: {
+		mCanvasContainer.Child(nullptr);
+		break;
+	}
+	case Type::Ellipse: {
+		auto ellipse = winrt::make_self<winui_drover_island::EllipseShape>(mUseVSIS);
+		mCanvasContainer.Child(*ellipse);
+		break;
+	}
+	case Type::DroverSample: {
+		auto droverIsland = winrt::make_self<winui_drover_island::DroverIsland>(mUseVSIS);
+		mCanvasContainer.Child(*droverIsland);
+		break;
+	}
+	}
+
+	const wchar_t* descriptions[] = {
+		L"No control is currently rendering.",
+		L"This is a sample ellipse rendered using a sample class EllipseShape inheriting from CanvasControl. Resize the window to trigger redraws on the control.",
+		L"This is a the placeholder that is supposed to host a Drover Island. It is using the class DroverIsland inheriting from CanvasControl. Resize the window to trigger redraws on the control.",
+	};
+	static_assert(_countof(descriptions) == static_cast<size_t>(Type::Last) + 1);
+	mDescription.Text(descriptions[static_cast<size_t>(type)]);
+
+	mControlType = type;
+}
+
+}

--- a/winui-drover-island/winui-drover-island/DroverIslandDemo.h
+++ b/winui-drover-island/winui-drover-island/DroverIslandDemo.h
@@ -14,28 +14,28 @@
 #pragma once
 
 #include <winrt/Microsoft.UI.Xaml.h>
-#include <winrt/winui_drover_island.h>
-
-#include "DroverIslandDemo.h"
 
 namespace winui_drover_island {
 
-class WinUIWindow
-{
+class DroverIslandDemo {
 public:
-	WinUIWindow();
-
-	void create();
-	void addContent();
-	void show();
-
-	const winrt::Microsoft::UI::Xaml::Window& window() const {
-		return mWindow;
-	};
+	DroverIslandDemo();
+	winrt::Microsoft::UI::Xaml::UIElement createContent();
 
 private:
-	winrt::Microsoft::UI::Xaml::Window mWindow{ nullptr };
-	DroverIslandDemo mDroverIslandDemo;
+	enum class Type { None, Ellipse, DroverSample, Last = DroverSample };
+
+	void renderCanvasControl(Type);
+	Type pickNextControl();
+
+	winrt::Microsoft::UI::Xaml::Controls::Grid mGrid{ nullptr };
+	winrt::Microsoft::UI::Xaml::Controls::Button::Click_revoker mClickRevoker;
+	winrt::Microsoft::UI::Xaml::Controls::CheckBox::Checked_revoker mCheckedRevoker;
+	winrt::Microsoft::UI::Xaml::Controls::CheckBox::Unchecked_revoker mUncheckedRevoker;
+	Type mControlType = Type::None;
+	winrt::Microsoft::UI::Xaml::Controls::Border mCanvasContainer{ nullptr };
+	winrt::Microsoft::UI::Xaml::Controls::TextBlock mDescription{ nullptr };
+	bool mUseVSIS = false;
 };
 
-}  // namespace winui_drover_island
+}

--- a/winui-drover-island/winui-drover-island/WinUIWindow.cpp
+++ b/winui-drover-island/winui-drover-island/WinUIWindow.cpp
@@ -35,8 +35,13 @@ void WinUIWindow::addContent() {
 	droverIslandDemo.Header(winrt::box_value(L"Drover Island"));
 	droverIslandDemo.Content(mDroverIslandDemo.createContent());
 
+	PivotItem dialogsAndPopupsDemo;
+	dialogsAndPopupsDemo.Header(winrt::box_value(L"Dialogs & Popups"));
+	dialogsAndPopupsDemo.Content(mDialogsAndPopupsDemo.content());
+
 	Pivot demos;
 	demos.Items().Append(std::move(droverIslandDemo));
+	demos.Items().Append(std::move(dialogsAndPopupsDemo));
 	mWindow.Content(demos);
 }
 

--- a/winui-drover-island/winui-drover-island/WinUIWindow.cpp
+++ b/winui-drover-island/winui-drover-island/WinUIWindow.cpp
@@ -13,8 +13,6 @@
 
 #include "pch.h"
 #include "WinUIWindow.h"
-#include "DroverIsland.h"
-#include "EllipseShape.h"
 
 #include <winrt/Windows.UI.h>
 
@@ -23,36 +21,6 @@ using namespace winrt::Microsoft::UI::Xaml;
 using namespace winrt::Windows::Foundation;
 
 namespace winui_drover_island {
-
-namespace {
-Grid createGrid() {
-	// Setup the grid.
-	auto column1 = ColumnDefinition{};
-	column1.Width(GridLength{ 1, GridUnitType::Star });
-	auto column2 = ColumnDefinition{};
-	column2.Width(GridLength{ 2, GridUnitType::Star });
-	auto column3 = ColumnDefinition{};
-	column3.Width(GridLength{ 1, GridUnitType::Star });
-	auto row1 = RowDefinition{};
-	row1.Height(GridLength{ 0, GridUnitType::Auto });
-	auto row2 = RowDefinition{};
-	row2.Height(GridLength{ 0, GridUnitType::Auto });
-	auto row3 = RowDefinition{};
-	row3.Height(GridLength{ 0, GridUnitType::Auto });
-	auto row4 = RowDefinition{};
-	row4.Height(GridLength{ 1, GridUnitType::Star });
-
-	Grid grid;
-	grid.ColumnDefinitions().Append(column1);
-	grid.ColumnDefinitions().Append(column2);
-	grid.ColumnDefinitions().Append(column3);
-	grid.RowDefinitions().Append(row1);
-	grid.RowDefinitions().Append(row2);
-	grid.RowDefinitions().Append(row3);
-	grid.RowDefinitions().Append(row4);
-	return grid;
-}
-}
 
 WinUIWindow::WinUIWindow() {	
 }
@@ -63,95 +31,7 @@ void WinUIWindow::create() {
 }
 
 void WinUIWindow::addContent() {
-	auto grid = createGrid();
-	mWindow.Content(grid);
-
-	auto checkbox = CheckBox{};
-	checkbox.Margin({ 20, 0, 0, 0 });
-	checkbox.Content(winrt::box_value(L"Enable Virtual Surface"));
-	mCheckedRevoker = checkbox.Checked(winrt::auto_revoke, [this](const IInspectable&, const RoutedEventArgs&) { mUseVSIS = true; });
-	mUncheckedRevoker = checkbox.Unchecked(winrt::auto_revoke, [this](const IInspectable&, const RoutedEventArgs&) { mUseVSIS = false; });
-	grid.Children().Append(checkbox);
-
-	auto title = TextBlock{};
-	title.Text(L"Playground for supporting Drover Islands in WinUI");
-	grid.Children().Append(title);
-	Grid::SetColumn(title, 1);
-	Grid::SetRow(title, 0);
-	title.HorizontalAlignment(HorizontalAlignment::Center);
-	title.Margin({ 0, 20, 0, 20 });
-	title.FontSize(32);
-	title.TextWrapping(TextWrapping::Wrap);
-
-	auto button = Button{};
-	button.Content(winrt::box_value(L"Click me to render the next control!"));
-	grid.Children().Append(button);
-	Grid::SetColumn(button, 1);
-	Grid::SetRow(button, 1);
-	button.HorizontalAlignment(HorizontalAlignment::Center);
-	mClickRevoker = button.Click(winrt::auto_revoke, [this](const IInspectable&, const RoutedEventArgs&) {
-		renderCanvasControl(pickNextControl());
-	});
-
-	auto description = TextBlock{};
-	grid.Children().Append(description);
-	Grid::SetColumn(description, 1);
-	Grid::SetRow(description, 2);
-	description.HorizontalAlignment(HorizontalAlignment::Center);
-	description.Margin({ 0, 20, 0, 20 });
-	description.TextWrapping(TextWrapping::Wrap);
-	mDescription = description;
-
-	mCanvasContainer = Border{};
-	grid.Children().Append(mCanvasContainer);
-	Grid::SetColumn(mCanvasContainer, 1);
-	Grid::SetRow(mCanvasContainer, 3);
-	Media::SolidColorBrush brush;
-	brush.Color(winrt::Windows::UI::Colors::Gray());
-	mCanvasContainer.Margin({0, 0, 0, 20});
-	mCanvasContainer.BorderBrush(brush);
-	mCanvasContainer.BorderThickness(Thickness{ 2, 2, 2, 2 });
-
-	renderCanvasControl(mControlType);
-}
-
-WinUIWindow::Type WinUIWindow::pickNextControl() {
-	switch (mControlType) {
-	case Type::Ellipse: return Type::DroverSample;
-	case Type::DroverSample: return Type::None;
-	default: return Type::Ellipse;
-	}
-}
-
-void WinUIWindow::renderCanvasControl(Type type) {
-	auto grid = mWindow.Content().as<Grid>();
-
-	switch (type) {
-	case Type::None: {
-		mCanvasContainer.Child(nullptr);
-		break;
-	}
-	case Type::Ellipse: {
-		auto ellipse = winrt::make_self<winui_drover_island::EllipseShape>(mUseVSIS);
-		mCanvasContainer.Child(*ellipse);
-		break;
-	}
-	case Type::DroverSample: {
-		auto droverIsland = winrt::make_self<winui_drover_island::DroverIsland>(mUseVSIS);
-		mCanvasContainer.Child(*droverIsland);
-		break;
-	}
-	}
-
-	const wchar_t* descriptions[] = {
-		L"No control is currently rendering.",
-		L"This is a sample ellipse rendered using a sample class EllipseShape inheriting from CanvasControl. Resize the window to trigger redraws on the control.",
-		L"This is a the placeholder that is supposed to host a Drover Island. It is using the class DroverIsland inheriting from CanvasControl. Resize the window to trigger redraws on the control.",
-	};
-	static_assert(_countof(descriptions) == static_cast<size_t>(Type::Last) + 1);
-	mDescription.Text(descriptions[static_cast<size_t>(type)]);
-
-	mControlType = type;
+	mWindow.Content(mDroverIslandDemo.createContent());
 }
 
 void WinUIWindow::show() {

--- a/winui-drover-island/winui-drover-island/WinUIWindow.cpp
+++ b/winui-drover-island/winui-drover-island/WinUIWindow.cpp
@@ -31,7 +31,13 @@ void WinUIWindow::create() {
 }
 
 void WinUIWindow::addContent() {
-	mWindow.Content(mDroverIslandDemo.createContent());
+	PivotItem droverIslandDemo;
+	droverIslandDemo.Header(winrt::box_value(L"Drover Island"));
+	droverIslandDemo.Content(mDroverIslandDemo.createContent());
+
+	Pivot demos;
+	demos.Items().Append(std::move(droverIslandDemo));
+	mWindow.Content(demos);
 }
 
 void WinUIWindow::show() {

--- a/winui-drover-island/winui-drover-island/winui-drover-island.vcxproj
+++ b/winui-drover-island/winui-drover-island/winui-drover-island.vcxproj
@@ -103,6 +103,7 @@
   <ItemGroup>
     <ClInclude Include="CanvasControl.h" />
     <ClInclude Include="DroverIsland.h" />
+    <ClInclude Include="DroverIslandDemo.h" />
     <ClInclude Include="EllipseShape.h" />
     <ClInclude Include="GfxD2DDeviceManager.h" />
     <ClInclude Include="GfxUtils.h" />
@@ -118,6 +119,7 @@
   <ItemGroup>
     <ClCompile Include="CanvasControl.cpp" />
     <ClCompile Include="DroverIsland.cpp" />
+    <ClCompile Include="DroverIslandDemo.cpp" />
     <ClCompile Include="EllipseShape.cpp" />
     <ClCompile Include="GfxD2DDeviceManager.cpp" />
     <ClCompile Include="GfxUtils.cpp" />

--- a/winui-drover-island/winui-drover-island/winui-drover-island.vcxproj
+++ b/winui-drover-island/winui-drover-island/winui-drover-island.vcxproj
@@ -102,6 +102,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CanvasControl.h" />
+    <ClInclude Include="DialogsAndPopupsDemo.h" />
     <ClInclude Include="DroverIsland.h" />
     <ClInclude Include="DroverIslandDemo.h" />
     <ClInclude Include="EllipseShape.h" />
@@ -118,6 +119,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="CanvasControl.cpp" />
+    <ClCompile Include="DialogsAndPopupsDemo.cpp" />
     <ClCompile Include="DroverIsland.cpp" />
     <ClCompile Include="DroverIslandDemo.cpp" />
     <ClCompile Include="EllipseShape.cpp" />

--- a/winui-drover-island/winui-drover-island/winui-drover-island.vcxproj.filters
+++ b/winui-drover-island/winui-drover-island/winui-drover-island.vcxproj.filters
@@ -16,6 +16,7 @@
     <ClCompile Include="GfxUtils.cpp" />
     <ClCompile Include="EllipseShape.cpp" />
     <ClCompile Include="DroverIslandDemo.cpp" />
+    <ClCompile Include="DialogsAndPopupsDemo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -26,6 +27,7 @@
     <ClInclude Include="GfxUtils.h" />
     <ClInclude Include="EllipseShape.h" />
     <ClInclude Include="DroverIslandDemo.h" />
+    <ClInclude Include="DialogsAndPopupsDemo.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Assets">

--- a/winui-drover-island/winui-drover-island/winui-drover-island.vcxproj.filters
+++ b/winui-drover-island/winui-drover-island/winui-drover-island.vcxproj.filters
@@ -4,8 +4,6 @@
     <ApplicationDefinition Include="App.xaml" />
   </ItemGroup>
   <ItemGroup>
-    <Midl Include="App.idl" />
-    <Midl Include="MainWindow.idl" />
     <Midl Include="CanvasControl.idl" />
   </ItemGroup>
   <ItemGroup>
@@ -17,6 +15,7 @@
     <ClCompile Include="DroverIsland.cpp" />
     <ClCompile Include="GfxUtils.cpp" />
     <ClCompile Include="EllipseShape.cpp" />
+    <ClCompile Include="DroverIslandDemo.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -26,6 +25,7 @@
     <ClInclude Include="DroverIsland.h" />
     <ClInclude Include="GfxUtils.h" />
     <ClInclude Include="EllipseShape.h" />
+    <ClInclude Include="DroverIslandDemo.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Assets">


### PR DESCRIPTION
Adds a demo to insert `ContentDialog` and `Popup` programmatically.

This mirrors our usage in UXP.

`Popup` requires insertion into a `Panel`, which we didn’t have to do under UWP.
`ContentDialog` needs to have `XamlRoot` set manually, which is not necessary under UWP.